### PR TITLE
Remove bower install from npm install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,5 @@
     "lumbar": "^2.0.1",
     "karma-jasmine": "^0.2.2",
     "karma-phantomjs-launcher": "^0.1.4"
-  },
-  "scripts": {
-    "install": "bower install"
   }
 }


### PR DESCRIPTION
For those of us using npm as the front-end package manager, forcing a bower install throws a wrench in the gears. I'd much rather be responsible for installing these dependencies myself.