### PR TITLE
change timeMin and timeMax params to use ISO date

### DIFF
--- a/src/gcal/gcal.js
+++ b/src/gcal/gcal.js
@@ -113,8 +113,8 @@ function transformOptions(sourceOptions, start, end, timezone, calendar) {
 
 	data = $.extend({}, sourceOptions.data || {}, {
 		key: apiKey,
-		timeMin: start.format(),
-		timeMax: end.format(),
+		timeMin: start.format("YYYY-MM-DD") + 'T' + '00:00:00+00:00',
+		timeMax: end.format("YYYY-MM-DD") + 'T' + '00:00:00+00:00',
 		timeZone: timezoneArg,
 		singleEvents: true,
 		maxResults: 9999


### PR DESCRIPTION
Google Calendar API v3 requires timeMin and timeMax to be formatted as yyyy-mm-ddT00:00:00+00:00 or sometime you will get a 400 bad request error