### PR TITLE
introduce auto-height to calculate the height based on parent element

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -505,7 +505,7 @@ function Calendar(element, instanceOptions) {
 
 
 	t.isHeightAuto = function() {
-		return options.contentHeight === 'auto' || options.height === 'auto';
+		return options.contentHeight === 'auto' || options.height === 'auto' || options.height === 'auto-height';
 	};
 	
 	
@@ -539,6 +539,11 @@ function Calendar(element, instanceOptions) {
 		else if (typeof options.height === 'number') { // exists and not 'auto'
 			suggestedViewHeight = options.height - (headerElement ? headerElement.outerHeight(true) : 0);
 		}
+		// try to determin the maximum height
+		else if (options.height === 'auto-height') {
+			suggestedViewHeight =  content.parent().height() - (headerElement ? headerElement.outerHeight(true) : 0);
+		}
+		// use aspect-ratio
 		else {
 			suggestedViewHeight = Math.round(content.width() / Math.max(options.aspectRatio, .5));
 		}


### PR DESCRIPTION
This enables fullcalender to derive the height of the grid from the parent height.