### PR TITLE
Fix week view column title for en-gb

### DIFF
--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -1,6 +1,8 @@
 
 $.fullCalendar.lang("en-gb", {
-	columnFormat: {
-		week: 'ddd D/M'
+	views: {
+		week: {
+			columnFormat: 'ddd D/M'
+		}
 	}
 });


### PR DESCRIPTION
Since Fullcalendar 2.3, the display of the column header in the week views is broken when the language is set to en-gb. Instead of the weekday and date, it just displays "object Object", see [this js-fiddle](http://jsfiddle.net/q1a40bno/2/). 