### PR TITLE
CommonJS support added

### DIFF
--- a/dist/fullcalendar.js
+++ b/dist/fullcalendar.js
@@ -6,9 +6,13 @@
 
 (function(factory) {
 	if (typeof define === 'function' && define.amd) {
+        // AMD, register as an anonymous module
 		define([ 'jquery', 'moment' ], factory);
-	}
-	else {
+	} else if (typeof exports === 'object') {
+        // Node/CommonJS
+        module.exports = factory(require('jquery'), require('moment'));
+    } else {
+        // Browser globals
 		factory(jQuery, moment);
 	}
 })(function($, moment) {


### PR DESCRIPTION
[UMD](https://github.com/umdjs/umd) support added to be compatible with Browserify (and others), like they recommend [here](https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js) for JQuery plugins. Maybe it would be good to add something like this to the documentation.

This library is [CommonJS](http://www.commonjs.org/) compatible, so you can use it in this way:

```javascript
var jquery = require('jquery'),
    moment = require('moment'),
    fullcalendar = require('fullcalendar')(jquery, moment);

    jquery('#calendar').fullCalendar({
          weekends: false // will hide Saturdays and Sundays
    });
    ...
```