### PR TITLE
Add option autoUpdate fixing issue 2293

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -415,6 +415,7 @@ function Calendar_constructor(element, overrides) {
 	var ignoreWindowResize = 0;
 	var date;
 	var events = [];
+	var autoUpdateIntId; // to cancel interval once view changes
 	
 	
 	
@@ -658,7 +659,17 @@ function Calendar_constructor(element, overrides) {
 
 	function getAndRenderEvents() {
 		if (!options.lazyFetching || isFetchNeeded(currentView.start, currentView.end)) {
-			fetchAndRenderEvents();
+			if(options.autoUpdate) {
+				if(autoUpdateIntId) {
+					clearInterval(autoUpdateIntId);
+				}
+				autoUpdateIntId = setInterval(function() {
+					fetchAndRenderEvents();
+				}, options.autoUpdate * 1000);
+			}
+			else {
+				fetchAndRenderEvents();
+			}
 		}
 		else {
 			renderEvents();

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -667,9 +667,7 @@ function Calendar_constructor(element, overrides) {
 					fetchAndRenderEvents();
 				}, options.autoUpdate * 1000);
 			}
-			else {
-				fetchAndRenderEvents();
-			}
+			fetchAndRenderEvents();
 		}
 		else {
 			renderEvents();

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -27,6 +27,7 @@ Calendar.defaults = {
 	
 	// event ajax
 	lazyFetching: true,
+	autoUpdate: 0,
 	startParam: 'start',
 	endParam: 'end',
 	timezoneParam: 'timezone',


### PR DESCRIPTION
Add option that forces calendar to fetch and render events every x
seconds.

I don't know if this is mergeable but since i, like others, were doing refetchEvents() on a setInterval, i thought to do this so that we can simply use a calendar option and so that event's don't flicker on update.

Thanks for this awesome plugin.