### PR TITLE
Regular slot duration is a multiple of 5

### DIFF
--- a/src/common/TimeGrid.js
+++ b/src/common/TimeGrid.js
@@ -71,7 +71,7 @@ var TimeGrid = Grid.extend({
 		var view = this.view;
 		var isRTL = this.isRTL;
 		var html = '';
-		var slotNormal = this.slotDuration.asMinutes() % 15 === 0;
+		var slotNormal = this.slotDuration.asMinutes() % 5 === 0;
 		var slotTime = moment.duration(+this.minTime); // wish there was .clone() for durations
 		var slotDate; // will be on the view's first day, but we only care about its time
 		var minutes;


### PR DESCRIPTION
I understand that a normal slot should be a multiple of 5.
It makes no sense to use "slotDuration = 20" and display all times.

If you disagree with the PR, please make this rule a configuration parameter.

Thanks and hugs!